### PR TITLE
Edited to add in all leads on Slack channel #website since 30 June.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2074,7 +2074,10 @@ simulator</a></li>
 	    <li><a class="a-link"
 	    href="http://www.biztree.com/"
 	    target="_blank">Business-in-a-Box</a></li>
-	    <li><a class="a-link" href="http://contractstandards.com/"
+      <li><a class="a-link"
+      href="https://www.clarilis.com/index.htm"
+      target="_blank">Clarilis</a> allows firms to generate templates and precedents</li>
+      <li><a class="a-link" href="http://contractstandards.com/"
 		   target="_blank">Contract Standards</a></li>
 	     <li><a class="a-link"
 	    href="https://contractmill.com/#how-it-works"
@@ -2104,7 +2107,10 @@ simulator</a></li>
 	    <li><a class="a-link" href="http://www.legalcontract.com/"
        target="_blank">LegalContract</a> has good decent wizards
        covering the US</li>
-	    <li><a class="a-link"
+       <li><a class="a-link"
+ 	    href="https://tryprose.com/"
+ 		   target="_blank">Prose</a></li>
+      <li><a class="a-link"
 	    href="http://radiantlaw.com/blog/document-automation-is-legal-rocketfuel"
 		   target="_blank">RadiantLaw</a></li>
 	     <li><a class="a-link"
@@ -2140,9 +2146,6 @@ simulator</a></li>
 	    Microsoft Word</li>
 	    <li><a class="a-link" href="http://www.weagree.com/"
 	    target="_blank">WeAgree</a></li>
-	     <li><a class="a-link" href="https://avvoka.com/"
-	    target="_blank">Avvoka</a> offers contract automation and
-	    pair drafting</li>
 	  </ul>
 
 	  <br>
@@ -2154,12 +2157,14 @@ simulator</a></li>
 	  <ul class="li-inline player-inline">
 	    <li><a class="a-link" href="https://autom.io/"
 	    target="_blank">Autom.io</a></li>
-	    <li><a class="a-link" href="http://bizibody.biz/"
+      <li><a class="a-link" href="https://avvoka.com/"
+      target="_blank">Avvoka</a> offers contract automation and
+      pair drafting</li>
+      <li><a class="a-link" href="http://bizibody.biz/"
 		   target="_blank">Bizibody</a></li>
 	    <li><a class="a-link"
 	    href="http://www.business-integrity.com/"
-	    target="_blank">ContractExpress by Business
-		Integrity</a></li>
+	    target="_blank">ContractExpress by Thomson Reuters</a></li>
 	     <li><a class="a-link" href="http://docassemble.org/"
 	    target="_blank">DocAssemble</a> is opensource (YAML and
 	    Python) and allows domain experts to build
@@ -2402,6 +2407,8 @@ simulator</a></li>
 	    <li><a class="a-link" href="http://precisely.se/"
 	    target="_blank">Precisely</a> is doing contract management
 	      software with pleasant UX</li>
+      <li><a class="a-link" href="https://www.springcm.com/"
+  	  target="_blank">SpringCM</a> is a document and contract management platform</li>
 	    <li><a class="a-link"
 	    href="https://www.viewabill.com/pages/home"
 	    target="_blank">Viewabill</a> promotes collaboration
@@ -3049,6 +3056,9 @@ href="http://www.asialawportal.com/2016/12/19/legal-startup-ai-law-set-to-deploy
 	    <li><b>Notarisation</b>&nbsp;<a class="a-link"
 	    href="https://notarize.com/"
 		       target="_blank">Notarize</a> is an app</li>
+      <li><b>Human resources</b>&nbsp;<a class="a-link"
+      href="https://hiringplan.io/about"
+           target="_blank">Hiringplan</a> helps plan employment compensation</li>
 	  </ul>
 
 	  <h3 class="lower-nav-el" id="other-interesting">Other


### PR DESCRIPTION
The following were added to the LegalTech map:
- Hiringplan
- ContractExpress (already there, but updated map to reflect that they have been bought over by Thomson Reuters)
- Avvoka (already there, but updated map so that it is in the correct alphabetical order)
- Clarilis
- Prose
- SpringCM