### PR TITLE
Replace hardcoded legalese.cloud with configurable env vars

### DIFF
--- a/src/app/console/console-utils.tsx
+++ b/src/app/console/console-utils.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, type ReactNode } from "react";
-import { AUTH_API_URL } from "@/lib/constants";
+import { AUTH_API_URL, SERVICE_DOMAIN } from "@/lib/constants";
 import { useConsole } from "./console-context";
 
 export const SESSION_TOKEN_KEY = "wos-session-token";
@@ -71,7 +71,7 @@ export function useServiceHealth(slug: string): ServiceHealth {
     }
 
     function fetchHealth() {
-      fetch(`https://${slug}.legalese.cloud/service/health`, {
+      fetch(`https://${slug}.${SERVICE_DOMAIN}/service/health`, {
         headers: authHeaders(),
         credentials: "include",
       })

--- a/src/app/console/logs/page.tsx
+++ b/src/app/console/logs/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useConsole } from "../console-context";
 import { authHeaders } from "../console-utils";
+import { SERVICE_DOMAIN } from "@/lib/constants";
 
 const POLL_INTERVAL_MS = 20_000;
 
@@ -50,7 +51,7 @@ export default function LogsPage() {
       try {
         const params = since ? `?since=${encodeURIComponent(since)}` : "";
         const res = await fetch(
-          `https://${slug}.legalese.cloud/service/logs${params}`,
+          `https://${slug}.${SERVICE_DOMAIN}/service/logs${params}`,
           { headers: authHeaders(), credentials: "include" },
         );
         if (!res.ok) {

--- a/src/app/console/org-setup.tsx
+++ b/src/app/console/org-setup.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { AUTH_API_URL } from "@/lib/constants";
+import { AUTH_API_URL, SERVICE_DOMAIN } from "@/lib/constants";
 import { authHeaders } from "./console-utils";
 
 function toSlug(name: string): string {
@@ -123,7 +123,7 @@ export function OrgSetup() {
             required
           />
           <p className="text-xs mt-1 text-gray-400 min-h-[1.25rem]">
-            {slugHint ?? "Used in your service URL: acme-corp.legalese.cloud"}
+            {slugHint ?? `Used in your service URL: acme-corp.${SERVICE_DOMAIN}`}
           </p>
         </div>
         {submitError && (

--- a/src/app/console/organization/page.tsx
+++ b/src/app/console/organization/page.tsx
@@ -7,8 +7,10 @@ import {
   authHeaders,
   useServiceHealth,
   planFromHealth,
+  SESSION_TOKEN_KEY,
   type ServiceHealth,
 } from "../console-utils";
+import { SERVICE_DOMAIN } from "@/lib/constants";
 import Link from "next/link";
 
 export default function OrganizationPage() {
@@ -92,7 +94,11 @@ function OrganizationInfo({
 // ── Deployment URL ──────────────────────────────────────────────────────
 
 function DeploymentUrl({ slug, health }: { slug: string; health: ServiceHealth }) {
-  const url = `https://${slug}.legalese.cloud`;
+  const url = `https://${slug}.${SERVICE_DOMAIN}`;
+  const token = typeof window !== "undefined" ? localStorage.getItem(SESSION_TOKEN_KEY) : null;
+  const redirectUrl = token
+    ? `${url}/auth/redirect?token=${encodeURIComponent(token)}&redirect_to=${encodeURIComponent(url)}`
+    : url;
   let dot: React.ReactNode;
   let suffix: React.ReactNode = null;
 
@@ -151,7 +157,7 @@ function DeploymentUrl({ slug, health }: { slug: string; health: ServiceHealth }
       <span className="inline-flex items-center gap-2 flex-wrap">
         <span className="inline-flex items-center gap-2">
           {dot}
-          <a href={url} target="_blank" rel="noopener noreferrer" className="hover:underline underline-offset-2">
+          <a href={redirectUrl} target="_blank" rel="noopener noreferrer" className="hover:underline underline-offset-2">
             {url}
           </a>
         </span>
@@ -172,7 +178,7 @@ function RestartServiceButton({ slug }: { slug: string }) {
     setState("restarting");
     setErrorMsg("");
     try {
-      const res = await fetch(`https://${slug}.legalese.cloud/service/restart`, {
+      const res = await fetch(`https://${slug}.${SERVICE_DOMAIN}/service/restart`, {
         method: "POST",
         headers: authHeaders(),
       });
@@ -290,7 +296,7 @@ function UsageChart({ slug, health, isAdmin }: { slug: string; health: ServiceHe
     let cancelled = false;
     setLoading(true);
 
-    fetch(`https://${slug}.legalese.cloud/billing/usage?period=${period}&days=${days}`, {
+    fetch(`https://${slug}.${SERVICE_DOMAIN}/billing/usage?period=${period}&days=${days}`, {
       headers: authHeaders(),
       credentials: "include",
     })

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,6 +1,7 @@
 export const CMS_NAME = "Legalese";
 export const SITE_NAME = "Legalese";
 export const SITE_DESCRIPTION = "Software is eating law. Legalese is building L4, a domain-specific programming language for legal.";
-export const SITE_URL = "https://legalese.com";
-export const AUTH_API_URL = process.env.NEXT_PUBLIC_AUTH_API_URL ?? "https://legalese.cloud";
+export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://legalese.com";
+export const SERVICE_DOMAIN = process.env.NEXT_PUBLIC_SERVICE_DOMAIN ?? "legalese.cloud";
+export const AUTH_API_URL = `https://${SERVICE_DOMAIN}`;
 


### PR DESCRIPTION
Introduces NEXT_PUBLIC_SERVICE_DOMAIN and NEXT_PUBLIC_SITE_URL env vars, derives AUTH_API_URL from SERVICE_DOMAIN, and routes deployment URL clicks through /auth/redirect for session handoff.